### PR TITLE
Better deduplication catchup. Happens to be simpler too

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -13,7 +13,8 @@ Following configurations can be set for deduplication job:
 | `hedera.dedupe.datasetName`                        |                  | Name of BigQuery dataset containing the tables |
 | `hedera.dedupe.fullFixedRate`                      | 84600000 (24 hr) | Rate at which full deduplication should be run. Format: milliseconds |
 | `hedera.dedupe.incrementalFixedRate`               | 300000 (5 min)   | Rate at which incremental deduplication should be run. Format: milliseconds |
-| `hedera.dedupe.incrementalInitialProbeInterval`    | 600 (10 min)     | Initial interval when probing for endTimestamp in incremental deduplication. Format: seconds |
+| `hedera.dedupe.catchupProbeIntervalSec`            | 21600 (6 hr)     | Interval to calculate endTimestamp when deduplication is catching up |
+| `hedera.dedupe.steadyStateProbeIntervalSec`        | 600 (10 min)     | Interval to calculate endTimestamp when deduplication is all caught up and in steady state |
 | `hedera.dedupe.metricsEnabled`                     | false            | Set to true to publish metrics to Stackdriver |
 | `hedera.dedupe.projectId`                          |                  | Project containing the BigQuery tables |
 | `hedera.dedupe.stateTableName`                     | state            | Name of state table |

--- a/hedera-deduplication-bigquery/src/main/java/com/hedera/dedupe/DedupeProperties.java
+++ b/hedera-deduplication-bigquery/src/main/java/com/hedera/dedupe/DedupeProperties.java
@@ -45,7 +45,8 @@ public class DedupeProperties {
 
     private boolean metricsEnabled = false;
 
-    private Long incrementalInitialProbeInterval = 600L; // in sec
+    private int catchupProbeIntervalSec = 6 * 60 * 60; // 6 hours
+    private int steadyStateProbeIntervalSec = 10 * 60; // 10 min
 
     public String getTransactionsTableFullName() {
         return projectId + "." + datasetName + "." + transactionsTableName;


### PR DESCRIPTION
Deduplication was catching up real slow earlier.
Dataset doesn't seem to have a txns for each second, because of
which probing would commonly stop at 2nd or 3rd step.

Changing to two phase method.
Essentially, dedupliation will be either catching up or in steady state
(processing recent txns dumped from streaming buffer to main partitions).
Using above to simplify 'probing' logic.
Probing will be done for just two intervals:
- small, for steady state, ~minutes
- large, for catching  up, ~hours

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Detailed description**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

